### PR TITLE
Update the CentOS to CentOS Stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM centos:stream8
 
 LABEL "maintainer"="L3D <l3d@c3woc.de>"
 LABEL "repository"="https://github.com/roles-ansible/check-ansible-centos-centos8-action.git"


### PR DESCRIPTION
The CentOS 8 is EOL, but quite the same content should be available in the Stream8 repo.